### PR TITLE
Fix for the displayed Role at Users grid

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -23,7 +23,7 @@ class UsersController extends Controller
                         'id' => $user->id,
                         'name' => $user->name,
                         'email' => $user->email,
-                        'owner' => $user->owner,
+                        'owner' => (bool) $user->owner,
                         'deleted_at' => $user->deleted_at,
                     ];
                 }),


### PR DESCRIPTION
This PR fix the displayed roles in the users grid at Manage Users page.
The problem occurs because the `index` method at `UsersController` returns `'owner' => $user->owner` as a `string` instead of `boolean`:

![Screen Shot 2019-04-03 at 10 45 21 AM](https://user-images.githubusercontent.com/1811607/55463467-cfa27f80-5601-11e9-9bf3-9b28f108f815.png)



This result  the condition `{{ user.owner ? 'Owner' : 'User' }}` in the `Index.Vue` template to allows return `true` so the displayed `Role` will be `Owner` for all users:

![Screen Shot 2019-04-03 at 10 44 19 AM](https://user-images.githubusercontent.com/1811607/55462796-3cb51580-5600-11e9-9db6-83da364f5002.png)


This PR cast `$user->owner` to `boolean` to solve the problem:

![Screen Shot 2019-04-03 at 10 43 51 AM](https://user-images.githubusercontent.com/1811607/55462797-3d4dac00-5600-11e9-947b-0d6652c5607a.png)

