### PR TITLE
Fix Filter button styling for Firefox

### DIFF
--- a/resources/js/Shared/SearchFilter.vue
+++ b/resources/js/Shared/SearchFilter.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="flex items-center">
     <div class="flex w-full bg-white shadow rounded">
-      <dropdown class="px-4 md:px-6 rounded-l border-r flex items-baseline hover:bg-grey-lightest focus:border-white focus:shadow-outline focus:z-10" placement="bottom-start">
-        <span class="text-grey-darkest hidden md:block">Filter</span>
-        <svg class="w-2 h-2 fill-grey-darker md:ml-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 961.243 599.998">
-          <path d="M239.998 239.999L0 0h961.243L721.246 240c-131.999 132-240.28 240-240.624 239.999-.345-.001-108.625-108.001-240.624-240z" />
-        </svg>
+      <dropdown class="px-4 md:px-6 rounded-l border-r hover:bg-grey-lightest focus:border-white focus:shadow-outline focus:z-10" placement="bottom-start">
+        <div class="flex items-baseline">
+          <span class="text-grey-darkest hidden md:block">Filter</span>
+          <svg class="w-2 h-2 fill-grey-darker md:ml-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 961.243 599.998">
+            <path d="M239.998 239.999L0 0h961.243L721.246 240c-131.999 132-240.28 240-240.624 239.999-.345-.001-108.625-108.001-240.624-240z" />
+          </svg>
+        </div>
         <div slot="dropdown" class="mt-2 px-4 py-6 w-screen shadow-lg bg-white rounded" :style="{ maxWidth: `${maxWidth}px` }">
           <slot />
         </div>


### PR DESCRIPTION
This PR fix the Filter button styling for Firefox, for some reason, Firefox didn't display `flex items-baseline` correctly when it applied at `Button` tag directly! So, I wrap the items inside the button in a `div` tag then applied `flex items-baseline` to it:

### Before:
![Screen Shot 2019-04-03 at 11 28 04 AM](https://user-images.githubusercontent.com/1811607/55465475-dfbc5e00-5605-11e9-8f6f-3af17589700c.png)

### After:
![Screen Shot 2019-04-03 at 11 28 26 AM](https://user-images.githubusercontent.com/1811607/55465476-e054f480-5605-11e9-8f4f-7cd29eca45eb.png)
