### PR TITLE
Fix for displayed Roles at Manage Users grid

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -13,6 +13,10 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 {
     use SoftDeletes, Authenticatable, Authorizable;
 
+    protected $casts = [
+        'owner' => 'boolean',
+    ];
+
     public function account()
     {
         return $this->belongsTo(Account::class);


### PR DESCRIPTION
This PR fix the displayed `Roles` in the `Users` grid at `Manage Users` page.
The problem occurs because the `index` method at `UsersController` returns `'owner' => $user->owner` as a `string` instead of `boolean`:

![Screen Shot 2019-04-03 at 10 45 21 AM](https://user-images.githubusercontent.com/1811607/55463467-cfa27f80-5601-11e9-9bf3-9b28f108f815.png)



This result  the condition `{{ user.owner ? 'Owner' : 'User' }}` in the `Index.Vue` template to allows return `true` so the displayed `Role` will be `Owner` for all users:

![Screen Shot 2019-04-03 at 10 44 19 AM](https://user-images.githubusercontent.com/1811607/55462796-3cb51580-5600-11e9-9db6-83da364f5002.png)


This PR cast `$user->owner` to `boolean` to solve the problem:

![Screen Shot 2019-04-03 at 10 43 51 AM](https://user-images.githubusercontent.com/1811607/55462797-3d4dac00-5600-11e9-947b-0d6652c5607a.png)

