### PR TITLE
Update `git clone` to use the HTTPS method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ A demo application to illustrate how Inertia.js works.
 Clone the repo locally:
 
 ```sh
-git clone git@github.com:inertiajs/pingcrm.git pingcrm
+git clone https://github.com/inertiajs/pingcrm.git pingcrm
 cd pingcrm
 ```
 


### PR DESCRIPTION
The SSH method required authentication.