### PR TITLE
Update tests to retrieve props from page

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,7 +16,7 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
 
         TestResponse::macro('props', function ($key = null) {
-            $props = json_decode(json_encode($this->original->getData()['props']), JSON_OBJECT_AS_ARRAY);
+            $props = json_decode(json_encode($this->original->getData()['page']['props']), JSON_OBJECT_AS_ARRAY);
 
             if ($key) {
                 return Arr::get($props, $key);


### PR DESCRIPTION
Grab the props from `page.props` instead of just `props`. Everything was failing for me initially with a message about `props` not being found, after this change everything passes.

Love love love Inertia, thanks so much!!