### PR TITLE
Fixed issue with spinner

### DIFF
--- a/resources/css/spinner.css
+++ b/resources/css/spinner.css
@@ -16,8 +16,6 @@
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);
-  -webkit-animation: loading 1s infinite linear;
-  animation: loading 1s infinite linear;
 }
 
 @keyframes loading {


### PR DESCRIPTION
The `.spinner` class and `.spinner-icon` both had the animation applied to it, causing it to go crazy. Removing these lines makes it function like it should, and like the demo of nprogress shows.