### PR TITLE
Remove axios to prevent multiple versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
         "@inertiajs/inertia": "^0.1.0",
         "@inertiajs/inertia-vue": "^0.1.0",
         "autosize": "^4.0.2",
-        "axios": "^0.18",
         "cross-env": "^5.1",
         "eslint": "^5.14.1",
         "eslint-plugin-vue": "^5.2.2",


### PR DESCRIPTION
When we lock the version in package.json npm will install a private version of axios for @inertia because it needs version 0.19.*.
This results in multiple axios version in the final javascript and introduce a problem when you try to use interceptors, because you cannot intercept the @inertia/node_modules/axios anymore.

I correct it here, because pingcrm is the goto example.
https://github.com/inertiajs/inertia/issues/52#issuecomment-524268967