### PR TITLE
Use `npm ci` to avoid package-lock update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ composer install
 Install NPM dependencies:
 
 ```sh
-npm install
+npm ci
 ```
 
 Build assets:


### PR DESCRIPTION
Running `npm ci` instead of `npm install` avoids `package-lock` file update and installation of patch versions different from upstream.

This can be useful to avoid git pollution and to have exactly the same version of npm dependencies when debugging or writing an example to reproduce an issue.

`npm ci` was added to NPM to be used in Continuous Integration setups (hence the `ci`) keeping exactly the same versions of packages listed in package-lock file.