### PR TITLE
tidy routes: adjusts web routes as follows:

### DIFF
--- a/app/Http/Controllers/ImagesController.php
+++ b/app/Http/Controllers/ImagesController.php
@@ -6,6 +6,11 @@ use League\Glide\Server;
 
 class ImagesController extends Controller
 {
+    public function __invoke(Server $glide)
+    {
+        return $this->show($glide);
+    }
+
     public function show(Server $glide)
     {
         return $glide->fromRequest()->response();

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -35,11 +35,9 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function map()
     {
-        $this->mapApiRoutes();
-
-        $this->mapWebRoutes();
-
-        //
+        //$this->mapApiRoutes();
+        //$this->mapWebRoutes();
+        $this->mapWebTidyRoutes();
     }
 
     /**
@@ -54,6 +52,29 @@ class RouteServiceProvider extends ServiceProvider
         Route::middleware('web')
              ->namespace($this->namespace)
              ->group(base_path('routes/web.php'));
+    }
+
+    /**
+     * Define the "web" routes for the application.
+     *
+     * These routes all receive session state, CSRF protection, etc.
+     *
+     * @return void
+     */
+    protected function mapWebTidyRoutes()
+    {
+        Route::middleware('web')
+            ->group(base_path('routes/web.auth.php'))
+        ;
+
+        Route::middleware('web')
+            ->namespace($this->namespace)
+            ->group(base_path('routes/web.tidy.php'))
+        ;
+
+        Route::middleware('web')
+            ->group(base_path('routes/web.debug.php'))
+        ;
     }
 
     /**

--- a/routes/web.auth.php
+++ b/routes/web.auth.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register web routes for your application. These
+| routes are loaded by the RouteServiceProvider within a group which
+| contains the "web" middleware group. Now create something great!
+|
+*/
+
+use \App\Http\Controllers\Auth\LoginController;
+
+Route::middleware('guest')->group(function() {
+    Route::get('login', [LoginController::class, 'showLoginForm'])->name('login');
+    Route::post('login', [LoginController::class, 'login'])->name('login.attempt');
+});
+
+Route::post('logout', [LoginController::class, 'logout'])->name('logout');

--- a/routes/web.debug.php
+++ b/routes/web.debug.php
@@ -1,0 +1,11 @@
+<?php
+
+// 500 error
+Route::get('500', function () {
+    // Force debug mode for this endpoint in the demo environment
+    if (App::environment('demo')) {
+        Config::set('app.debug', true);
+    }
+
+    echo $fail;
+});

--- a/routes/web.tidy.php
+++ b/routes/web.tidy.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register web routes for your application. These
+| routes are loaded by the RouteServiceProvider within a group which
+| contains the "web" middleware group. Now create something great!
+|
+*/
+
+Route::middleware('auth')->group(function() {
+
+    // Dashboard (invokable)
+    Route::get('/', DashboardController::class)->name('dashboard');
+
+    // Reports (invokable)
+    Route::get('reports', ReportsController::class)->name('reports');
+
+    // Users (resource, restorable)
+    Route::resource('users', UsersController::class)
+        ->names(['index' => 'users'])
+    ;
+    Route::put('users/{user}/restore', 'UsersController@restore')
+        ->name('users.restore')
+    ;
+
+    // Organizations (resource, restorable)
+    Route::resource('organizations', OrganizationsController::class)
+        ->names(['index' => 'organizations'])
+    ;
+    Route::put('organizations/{organization}/restore', 'OrganizationsController@restore')
+        ->name('organizations.restore')
+    ;
+
+    // Contacts (resource, restorable)
+    Route::resource('contacts', ContactsController::class)
+        ->names(['index' => 'contacts'])
+    ;
+    Route::put('contacts/{contact}/restore', 'ContactsController@restore')
+        ->name('contacts.restore')
+    ;
+});
+
+// Images (invokable)
+Route::get('/img/{path}', ImagesController::class)
+    ->where('path', '.*')
+;


### PR DESCRIPTION
### Commit message(s)
* 1st) splits `web.php` into `web.auth.php` (login, logout), `web.tidy.php` (main routes), `web.debug.php` (the 500 route demo);
* 2nd) modifies `RouteServiceProvider` to load the routes; note the original `mapWebRoutes()` remains intact, but commented;
* 3rd) leverages _invokable_ and _resource_ controllers fully; adds custom routes for the '@restore' actions not included in resource controllers;
* 4th) registers the resource routing with the qualified controller class (ie `UsersController::class`); '@restore' routes still mapped with strings;
* and made the **ImagesController** effectively an _invokable_ controller, like the single-method, invokable Dashboard and Reports controllers.

---
### Notes
_I do realize_ these routes have been [called into question previously](https://github.com/inertiajs/pingcrm/issues/9), and that [similar efforts in another PR were ultimately discarded (grouping routes declined in #22)](https://github.com/inertiajs/pingcrm/pull/22), with the express desire and intent being to keep the routes "super explicit". If that remains the case, then it is understood this will also not be merged...

But, I wanted to open the PR anyway, to say that this week is my first good look at Inertia.js and, after reading the "how does it work" and "protocol" pages in the documentation, one of the first things I did was open this reference implementation and examine the routes. And when I did see this routes file I nearly closed all things Inertia and planned to forget about it on the basis of "_if my routes need to look like that, I'm not using it_" ...

But I looked closer and realized that with the exception of the route name attached to the `index` action, and the additional `restore` action, these were in fact just resource routes and controllers at work.

I empathize with 'super explicit' routes for the benefit of newcomers to the (laravel) framework, I also think the `web.tidy.php` is worthy of consideration, as contrasted to the original `web.php` routes definitions, and which offers routing examples of:
 * Invokable (single-action) controllers
 * Resource (CRUD) controllers, using the qualified `MyController::class` syntax, and
 * Custom action routes, left in-tact for e.g. `'ContactsController@restore'` actions/methods, and still using the familiar string syntax to register the action.

### Summary
So, this pull request is actually *more* lines of code than the original, spread across multiple files, but it does also demonstrate the multiple ways to register routes in laravel along with the utility and expressiveness of that routing system. And to those already familiar with laravel, it becomes immediately evident that Inertia does in fact work with any/all options.

---

### Thanks
Thanks for looking it over and for the consideration. And Thanks for Inertia :)