### PR TITLE
Hash password only once

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -32,7 +32,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
 
     public function setPasswordAttribute($password)
     {
-        $this->attributes['password'] = Hash::make($password);
+        $this->attributes['password'] = Hash::needsRehash($password) ? Hash::make($password) : $password;
     }
 
     public function photoUrl(array $attributes)


### PR DESCRIPTION
When a user resets their password, the password would be double hashed and the user locked out of their account.

Ensure we only hash the password if it needs to be hashed. If it has already been hashed, just return the password as-is.