### PR TITLE
assert props fragment

### DIFF
--- a/tests/Feature/ContactsTest.php
+++ b/tests/Feature/ContactsTest.php
@@ -40,11 +40,13 @@ class ContactsTest extends TestCase
             ->assertPropCount('contacts.data', 5)
             ->assertPropValue('contacts.data', function ($contacts) {
                 $this->assertEquals(
-                    ['id', 'name', 'phone', 'city', 
-                    'deleted_at', 'organization'],
+                    ['id', 'name', 'phone', 'city', 'deleted_at', 'organization'],
                     array_keys($contacts[0])
                 );
-            });
+            })
+            ->assertPropsFragment($this->user->only('id', 'first_name', 'last_name', 'email'))
+            ->assertPropsFragment($this->user->account->only('id', 'name'))
+            ->assertPropsFragment(Contact::first()->only('id', 'name', 'phone', 'city'));
     }
 
     public function test_can_search_for_contacts()
@@ -63,7 +65,8 @@ class ContactsTest extends TestCase
             ->assertPropCount('contacts.data', 1)
             ->assertPropValue('contacts.data', function ($contacts) {
                 $this->assertEquals('Greg Andersson', $contacts[0]['name']);
-            });
+            })
+            ->assertPropsFragment(Contact::first()->only('id', 'name'));
     }
 
     public function test_cannot_view_deleted_contacts()

--- a/tests/Feature/ContactsTest.php
+++ b/tests/Feature/ContactsTest.php
@@ -44,9 +44,10 @@ class ContactsTest extends TestCase
                     array_keys($contacts[0])
                 );
             })
-            ->assertPropsFragment($this->user->only('id', 'first_name', 'last_name', 'email'))
-            ->assertPropsFragment($this->user->account->only('id', 'name'))
-            ->assertPropsFragment(Contact::first()->only('id', 'name', 'phone', 'city'));
+            ->assertInertiaFragment($this->user->only('id', 'first_name', 'last_name', 'email'))
+            ->assertInertiaFragment($this->user->account->only('id', 'name'))
+            ->assertInertiaFragment(Contact::first()->only('id', 'name', 'phone', 'city'))
+            ->assertInertiaMissing(['name' => 'foo', 'phone' => '99999999']);
     }
 
     public function test_can_search_for_contacts()
@@ -66,7 +67,7 @@ class ContactsTest extends TestCase
             ->assertPropValue('contacts.data', function ($contacts) {
                 $this->assertEquals('Greg Andersson', $contacts[0]['name']);
             })
-            ->assertPropsFragment(Contact::first()->only('id', 'name'));
+            ->assertInertiaFragment(Contact::first()->only('id', 'name'));
     }
 
     public function test_cannot_view_deleted_contacts()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert;
 use Illuminate\Foundation\Testing\TestResponse;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Str;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -16,7 +17,7 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
 
         TestResponse::macro('props', function ($key = null) {
-            $props = json_decode(json_encode($this->original->getData()['page']['props']), JSON_OBJECT_AS_ARRAY);
+            $props = json_decode($this->actual(), JSON_OBJECT_AS_ARRAY);
 
             if ($key) {
                 return Arr::get($props, $key);
@@ -49,6 +50,28 @@ abstract class TestCase extends BaseTestCase
             Assert::assertCount($count, $this->props($key));
 
             return $this;
+        });
+    
+        TestResponse::macro('assertPropsFragment', function ($data) {
+            $actual = $this->actual();
+
+            foreach (Arr::sortRecursive($data) as $key => $value) {
+                $expected = $this->jsonSearchStrings($key, $value);
+    
+                Assert::assertTrue(
+                    Str::contains($actual, $expected),
+                    'Unable to find props fragment: '.PHP_EOL.PHP_EOL.
+                    '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
+                    'within'.PHP_EOL.PHP_EOL.
+                    "[{$actual}]."
+                );
+            }
+        
+            return $this;
+        });
+
+        TestResponse::macro('actual', function () {
+            return json_encode($this->original->getData()['page']['props']);
         });
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,10 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
+        TestResponse::macro('actual', function () {
+            return json_encode($this->original->getData()['page']['props']);
+        });
+
         TestResponse::macro('props', function ($key = null) {
             $props = json_decode($this->actual(), JSON_OBJECT_AS_ARRAY);
 
@@ -52,7 +56,7 @@ abstract class TestCase extends BaseTestCase
             return $this;
         });
     
-        TestResponse::macro('assertPropsFragment', function ($data) {
+        TestResponse::macro('assertInertiaFragment', function ($data) {
             $actual = $this->actual();
 
             foreach (Arr::sortRecursive($data) as $key => $value) {
@@ -60,7 +64,7 @@ abstract class TestCase extends BaseTestCase
     
                 Assert::assertTrue(
                     Str::contains($actual, $expected),
-                    'Unable to find props fragment: '.PHP_EOL.PHP_EOL.
+                    'Unable to find JSON fragment: '.PHP_EOL.PHP_EOL.
                     '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
                     'within'.PHP_EOL.PHP_EOL.
                     "[{$actual}]."
@@ -70,8 +74,28 @@ abstract class TestCase extends BaseTestCase
             return $this;
         });
 
-        TestResponse::macro('actual', function () {
-            return json_encode($this->original->getData()['page']['props']);
+        TestResponse::macro('assertInertiaMissing', function ($data) {
+            $actual = $this->actual();
+
+            foreach (Arr::sortRecursive($data) as $key => $value) {
+                $unexpected = $this->jsonSearchStrings($key, $value);
+
+                Assert::assertFalse(
+                    Str::contains($actual, $unexpected),
+                    'Found unexpected JSON fragment: '.PHP_EOL.PHP_EOL.
+                    '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
+                    'within'.PHP_EOL.PHP_EOL.
+                    "[{$actual}]."
+                );
+            }
+
+            return $this;
+        });
+
+        TestResponse::macro('dumpInertia', function () {
+            dump(json_decode($this->actual(), JSON_OBJECT_AS_ARRAY));
+
+            return $this;
         });
     }
 }


### PR DESCRIPTION
This PR enables to assert if a props fragment exists in the response. It behaves like `assertJsonFragment`.

```php
->assertPropsFragment($this->user->only('id', 'first_name', 'last_name', 'email'))
->assertPropsFragment($this->user->account->only('id', 'name'))
->assertPropsFragment(Contact::first()->only('id', 'name', 'phone', 'city'));
```