### PR TITLE
Replace import statement with require.  

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -18,7 +18,7 @@ new Vue({
   render: h => h(InertiaApp, {
     props: {
       initialPage: JSON.parse(app.dataset.page),
-      resolveComponent: name => import(`@/Pages/${name}`).then(module => module.default),
+      resolveComponent: name => require(`@/Pages/${name}`).default,
     },
   }),
 }).$mount(app)


### PR DESCRIPTION
Using 'import' results in webpack/postcss failing to compile modules when Vue single file components include style tags.  Changing to 'require' syntax resolves issue.  Tests continue to pass following this change.