### PR TITLE
refactor: improve user share in middleware

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -39,17 +39,7 @@ class HandleInertiaRequests extends Middleware
         return array_merge(parent::share($request), [
             'auth' => function () use ($request) {
                 return [
-                    'user' => $request->user() ? [
-                        'id' => $request->user()->id,
-                        'first_name' => $request->user()->first_name,
-                        'last_name' => $request->user()->last_name,
-                        'email' => $request->user()->email,
-                        'role' => $request->user()->role,
-                        'account' => [
-                            'id' => $request->user()->account->id,
-                            'name' => $request->user()->account->name,
-                        ],
-                    ] : null,
+                    'user' => optional($request->user())->only('id', 'first_name', 'last_name', 'email', 'account')
                 ];
             },
             'flash' => function () use ($request) {


### PR DESCRIPTION
This PR proposes to change the syntax of the `user` share to avoid repetition. The ternary always bugged me, and I think this is cleaner and more Laravel-ish. 

```php
return array_merge(parent::share($request), [
    'auth' => function () use ($request) {
        return [
            'user' => optional($request->user())->only('id', 'first_name', 'last_name', 'email', 'account')
        ];
    },
]);
```

This does not behave exactly the same as previously though: `account` here will share its timestamps, `created_at` and `updated_at`. I figured it wasn't a big deal in this case. 

In PHP 8, and with arrow functions, this would be even cleaner: 

```php
return array_merge(parent::share($request), [
    'auth' => fn () => [
        'user' => $request->user()?->only('id', 'first_name', 'last_name', 'email', 'account')
    ];
]);
```

---

Slightly related: there was a `role` property, but it was always `null` (I think?) because there were no accessor for it and it's not a column. It's used as a scope, but an accessor like this would be required for the previous code to return a value for `role`: 

```php
// app/Models/User.php

public function getRoleAttribute()
{
    return $this->owner ? 'owner' : 'user';
}
```

I didn't add it and didn't add it in `only` either because it's not used in the Vue files.