### PR TITLE
Upgrade manual visit method replace with get

### DIFF
--- a/resources/js/Pages/Contacts/Index.vue
+++ b/resources/js/Pages/Contacts/Index.vue
@@ -95,7 +95,7 @@ export default {
     form: {
       handler: throttle(function() {
         let query = pickBy(this.form)
-        this.$inertia.replace(this.route('contacts', Object.keys(query).length ? query : { remember: 'forget' }))
+        this.$inertia.get(this.route('contacts'), Object.keys(query).length ? query : { remember: 'forget' }, { preserveState: true })
       }, 150),
       deep: true,
     },

--- a/resources/js/Pages/Organizations/Index.vue
+++ b/resources/js/Pages/Organizations/Index.vue
@@ -87,7 +87,7 @@ export default {
     form: {
       handler: throttle(function() {
         let query = pickBy(this.form)
-        this.$inertia.replace(this.route('organizations', Object.keys(query).length ? query : { remember: 'forget' }))
+        this.$inertia.get(this.route('organizations'), Object.keys(query).length ? query : { remember: 'forget' }, { preserveState: true })
       }, 150),
       deep: true,
     },

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -92,7 +92,7 @@ export default {
     form: {
       handler: throttle(function() {
         let query = pickBy(this.form)
-        this.$inertia.replace(this.route('users', Object.keys(query).length ? query : { remember: 'forget' }))
+        this.$inertia.get(this.route('users'), Object.keys(query).length ? query : { remember: 'forget' }, { preserveState: true })
       }, 150),
       deep: true,
     },


### PR DESCRIPTION
#119

Using the search feature in the demo app throws warning messages in the console saying,

`Inertia.replace() has been deprecated and will be removed in a future release. Please use Inertia.get() instead.`

I've switched it around to use `get` instead, hope I didn't miss something. Thank you.
