### PR TITLE
Inerita replace() deprecated

### DIFF
--- a/resources/js/Pages/Contacts/Index.vue
+++ b/resources/js/Pages/Contacts/Index.vue
@@ -93,9 +93,11 @@ export default {
   },
   watch: {
     form: {
-      handler: throttle(function() {
+      handler: throttle(function () {
         let query = pickBy(this.form)
-        this.$inertia.replace(this.route('contacts', Object.keys(query).length ? query : { remember: 'forget' }))
+        this.$inertia.get(this.route('contacts', Object.keys(query).length ? query : { remember: 'forget' })), 
+        {},
+        { preserveState: true }
       }, 150),
       deep: true,
     },

--- a/resources/js/Pages/Organizations/Index.vue
+++ b/resources/js/Pages/Organizations/Index.vue
@@ -87,7 +87,9 @@ export default {
     form: {
       handler: throttle(function() {
         let query = pickBy(this.form)
-        this.$inertia.replace(this.route('organizations', Object.keys(query).length ? query : { remember: 'forget' }))
+        this.$inertia.get(this.route('organizations', Object.keys(query).length ? query : { remember: 'forget' })),
+        {},
+        { preserveState: true }
       }, 150),
       deep: true,
     },

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -92,7 +92,9 @@ export default {
     form: {
       handler: throttle(function() {
         let query = pickBy(this.form)
-        this.$inertia.replace(this.route('users', Object.keys(query).length ? query : { remember: 'forget' }))
+        this.$inertia.get(this.route('users', Object.keys(query).length ? query : { remember: 'forget' })),
+        {},
+        { preserveState: true }
       }, 150),
       deep: true,
     },


### PR DESCRIPTION
Change inertia deprecated ```replace()``` to ```get()``` when filtering results on index pages.
Using ```preserveState: true``` to maintain focus while typing in a search query.

Deprecated message for reference:
```js
Inertia.replace() has been deprecated and will be removed in a future release. Please use Inertia.get() instead.
```

[inertia-0.6.0#inertia-replace-deprecated](https://inertiajs.com/releases/inertia-0.6.0#inertia-replace-deprecated)