### PR TITLE
fix: only show flash messages on success callback so that they aren't…

### DIFF
--- a/resources/js/Shared/FlashMessages.vue
+++ b/resources/js/Shared/FlashMessages.vue
@@ -26,16 +26,24 @@
 </template>
 
 <script>
+import { Inertia } from '@inertiajs/inertia'
+
 export default {
   data() {
     return {
-      show: true,
+      show: false,
     }
   },
   watch: {
     '$page.props.flash': {
       handler() {
-        this.show = true
+        this.show = false
+
+        Inertia.on('success', () => {
+          if (this.$page.props.flash.error !== null || this.$page.props.flash.success !== null) {
+            this.show = true
+          }
+        })
       },
       deep: true,
     },


### PR DESCRIPTION
… being triggered by navigation back

This implements a solution as described in https://github.com/inertiajs/inertia/issues/1643#issuecomment-1782210420.