### PR TITLE
Replace polyfill.io by cloudflare cdn

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -6,10 +6,10 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 
     {{-- Inertia --}}
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=smoothscroll,NodeList.prototype.forEach,Promise,Object.values,Object.assign" defer></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=smoothscroll,NodeList.prototype.forEach,Promise,Object.values,Object.assign" defer></script>
 
     {{-- Ping CRM --}}
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=String.prototype.startsWith" defer></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=String.prototype.startsWith" defer></script>
 
     @vite('resources/js/app.js')
     @inertiaHead


### PR DESCRIPTION
Since polyfill.io is down, replace it with cloudflare cdn https://news.ycombinator.com/item?id=40805827

"Polyfill.io has been serving malware for months via its CDN, after the project's open source maintainer sold the service to a company based in China."